### PR TITLE
Add a workflow to publish the library on npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the project
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# .npmrc file to handle npm authentication
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "test": "jest",
     "build": "tsc",
-    "ci": "npm run build && npm test"
+    "ci": "npm run build && npm test",
+    "publish": "npm publish"
   },
   "author": "Alex Szabo (delanni.alex@gmail.com)",
   "license": "MIT",


### PR DESCRIPTION
Add a workflow to publish the library on npm.

* **package.json**
  - Add `publish` script to the `scripts` section to run `npm publish`.

* **.github/workflows/publish.yml**
  - Create a new workflow file to handle publishing to npm.
  - Trigger the workflow using `workflow_dispatch`.
  - Set up Node.js environment and install dependencies.
  - Build the project using `npm run build`.
  - Publish the package to npm using `npm publish`.
  - Authenticate with npm using a secret token stored in the repository's secrets.

* **.npmrc**
  - Create a new `.npmrc` file to handle npm authentication.
  - Add `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` to the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/delanni/if-expression/pull/27?shareId=4a4881d0-3113-49f3-b406-df86bbe22e81).